### PR TITLE
gh-8: updated chart to use dns targets

### DIFF
--- a/stable/gateway/Chart.yaml
+++ b/stable/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/gateway/Chart.yaml
+++ b/stable/gateway/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.2
+appVersion: 0.2.5

--- a/stable/gateway/values.yaml
+++ b/stable/gateway/values.yaml
@@ -53,11 +53,11 @@ tolerations: []
 affinity: {}
 
 extractor:
-  address: "extractor:8090"
+  address: "dns:///extractor:8090"
   secretName: ""
 
 tracker:
-  address: "tracker:8090"
+  address: "dns:///tracker:8090"
   secretName: ""
 
 tls:

--- a/stable/indexer/Chart.yaml
+++ b/stable/indexer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/stable/indexer/Chart.yaml
+++ b/stable/indexer/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.3
+appVersion: 0.2.4

--- a/stable/indexer/values.yaml
+++ b/stable/indexer/values.yaml
@@ -49,11 +49,11 @@ affinity: {}
 schedule: "@daily"
 
 extractor:
-  address: "extractor:8090"
+  address: "dns:///extractor:8090"
   secretName: ""
 
 tracker:
-  address: "tracker:8090"
+  address: "dns:///tracker:8090"
   secretName: ""
 
 workers: 5

--- a/stable/tracker/Chart.yaml
+++ b/stable/tracker/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.3
+appVersion: 0.2.4


### PR DESCRIPTION
Resolves gh-8

Requires the following to be merged and published:
https://github.com/deps-cloud/indexer/pull/16
https://github.com/deps-cloud/gateway/pull/8

Requires appVersion bump for indexer and gateway.